### PR TITLE
feat: clear form fields and encrypt PDFs; add Cursor rules template

### DIFF
--- a/.cursor/rules/template.rules
+++ b/.cursor/rules/template.rules
@@ -1,0 +1,22 @@
+---
+description: "Global Memory System (KISS)"
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Memory routing SOP (auto)
+# - If the user says "add to rules": only put short, universal, stable rules here.
+# - If the user says "add to memory": put procedures/checklists in Pepper (~/memo/global-memories).
+# - If it is historical/RCA/old versions: put it in global-kb (~/Code/global-kb) or OS KB (kb CLI).
+#
+# Secrets policy (local dev):
+# - For local development on this machine, it is acceptable to keep MCP credentials as static values in ~/.cursor/mcp.json.
+# - Never commit secrets to open source repos or store them inside repo rules files.
+#
+# Pepper (git) canonical files:
+# - memory_bank_read("global-memories", "memory-sop.md")
+# - memory_bank_read("global-memories", "coding-standards-v9-1.md")
+# - memory_bank_read("global-memories", "quick-reference-card.md")
+#
+# Quality gates before calling work "done": tests pass; errors handled; docs updated.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project follows Keep a Changelog and Semantic Versioning.
 ### Added
 - Text watermark or stamp tool implemented as FreeText annotations.
 - PyMuPDF-powered tools: comments (Text annotations) and signature image add, update, resize, remove.
+- Form-field value clearing tool: clear (delete) values while keeping fields fillable.
+- PDF encryption tool: password-protect PDFs (use after signing to protect signed PDFs).
 - Repository license switched to GNU AGPL-3.0.
 
 ## 0.1.0

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Restart Cursor after saving.
 ## Available tools (initial)
 - `get_pdf_form_fields(pdf_path)`: list fields and count.
 - `fill_pdf_form(input_path, output_path, data, flatten=False)`: fill fields; optional flatten (uses fillpdf if available, else pypdf fallback).
+- `clear_pdf_form_fields(input_path, output_path, fields=None)`: clear (delete) values for selected form fields while keeping fields fillable.
 - `flatten_pdf(input_path, output_path)`: flatten forms/annotations.
 - `merge_pdfs(pdf_list, output_path)`: merge multiple PDFs.
 - `extract_pages(input_path, pages, output_path)`: 1-based pages, supports negatives (e.g., -1 = last).
@@ -80,6 +81,7 @@ Restart Cursor after saving.
 - `add_signature_image(input_path, output_path, page, image_path, rect)`: add a signature image to a page (returns `signature_xref`).
 - `update_signature_image(input_path, output_path, page, signature_xref, image_path=None, rect=None)`: update or resize a signature image.
 - `remove_signature_image(input_path, output_path, page, signature_xref)`: remove a signature image.
+- `encrypt_pdf(input_path, output_path, user_password, owner_password=None, ...)`: encrypt (password-protect) a PDF (use after `add_signature_image` to protect a signed PDF).
 
 ## Conventions
 - Paths should be absolute; outputs are created with parent directories if missing.

--- a/pdf_mcp/server.py
+++ b/pdf_mcp/server.py
@@ -60,6 +60,46 @@ def flatten_pdf(input_path: str, output_path: str) -> Dict[str, Any]:
 
 @mcp.tool()
 @_handle_errors
+def clear_pdf_form_fields(
+    input_path: str,
+    output_path: str,
+    fields: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Clear (delete) values for PDF form fields while keeping fields fillable."""
+    return pdf_tools.clear_pdf_form_fields(input_path, output_path, fields=fields)
+
+
+@mcp.tool()
+@_handle_errors
+def encrypt_pdf(
+    input_path: str,
+    output_path: str,
+    user_password: str,
+    owner_password: Optional[str] = None,
+    allow_printing: bool = True,
+    allow_modifying: bool = False,
+    allow_copying: bool = False,
+    allow_annotations: bool = False,
+    allow_form_filling: bool = True,
+    use_128bit: bool = True,
+) -> Dict[str, Any]:
+    """Encrypt (password-protect) a PDF using pypdf."""
+    return pdf_tools.encrypt_pdf(
+        input_path=input_path,
+        output_path=output_path,
+        user_password=user_password,
+        owner_password=owner_password,
+        allow_printing=allow_printing,
+        allow_modifying=allow_modifying,
+        allow_copying=allow_copying,
+        allow_annotations=allow_annotations,
+        allow_form_filling=allow_form_filling,
+        use_128bit=use_128bit,
+    )
+
+
+@mcp.tool()
+@_handle_errors
 def merge_pdfs(pdf_list: List[str], output_path: str) -> Dict[str, Any]:
     """Merge multiple PDFs into a single file."""
     return pdf_tools.merge_pdfs(pdf_list, output_path)


### PR DESCRIPTION
- add clear_pdf_form_fields + encrypt_pdf tools\n- make form filling robust on non-standard AcroForms\n- update README + CHANGELOG\n- add repo-local .cursor/rules template (memory routing SOP)\n- tests: unit + MCP-layer smoke; private fixture QA (fill->clear->sign->encrypt)