### PR TITLE
chore: add pre-commit pre-push gates (tests + smoke)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: pdf-mcp-prepush-gates
+        name: pdf-mcp pre-push gates (tests + smoke)
+        entry: bash -lc "make prepush"
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+
+

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PY ?= $(VENV)/bin/python
 PIP ?= $(UV) pip
 
 .PHONY: venv install test clean
+.PHONY: smoke prepush
 
 venv: $(VENV)/bin/python
 
@@ -15,6 +16,11 @@ install: venv
 
 test: install
 	. $(VENV)/bin/activate && PYTHONWARNINGS=default pytest
+
+smoke: install
+	. $(VENV)/bin/activate && $(PY) scripts/cursor_smoke.py --out-dir /tmp/pdf-handler-prepush-smoke
+
+prepush: test smoke
 
 clean:
 	rm -rf $(VENV) .pytest_cache **/__pycache__

--- a/PROJECT_MEMO/RELEASE_RUNBOOK.md
+++ b/PROJECT_MEMO/RELEASE_RUNBOOK.md
@@ -5,6 +5,7 @@ Canonical changelog: `CHANGELOG.md` (Keep a Changelog + SemVer).
 ## What “release-ready” means here
 
 - `make test` passes
+- `make smoke` passes (hard requirements)
 - hard requirements verified (see `docs/CURSOR_SMOKE_TEST.md`)
 - `README.md` + `CHANGELOG.md` updated and consistent
 
@@ -16,6 +17,7 @@ Canonical changelog: `CHANGELOG.md` (Keep a Changelog + SemVer).
 git checkout main
 git pull --ff-only
 make test
+make smoke
 ```
 
 2. Update version (SemVer) in `pyproject.toml`.
@@ -38,6 +40,19 @@ git push origin main --tags
 6. GitHub Release:
 - Create a release for tag `vX.Y.Z`
 - Paste the `CHANGELOG.md` section for `X.Y.Z`
+
+## Pre-push automation (recommended)
+
+Install pre-commit hooks so you catch CI failures before pushing:
+
+```bash
+pre-commit install
+pre-commit install --hook-type pre-push
+```
+
+What it runs on `git push`:
+- `make test`
+- `make smoke`
 
 ## Canonical SOP (recommended)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pre-commit"]
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
## Summary

What does this PR change and why?

## Scope

- **Feature/bug**:
- **Breaking change**: yes/no (if yes: link approval comment)
- **MCP tools changed**: list tool names or “none”

## Quality gates (required)

- [ ] `make test` passes locally
- [ ] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [ ] Tests added/updated for new behavior (`tests/`)
- [ ] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [ ] `README.md` updated (tool list / usage) if needed
- [ ] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [ ] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

Describe how you verified by invoking the MCP tools and re-reading outputs.

## Notes

Links to issues, meeting distillation issue, sample PDFs (private repo), etc.


