### PR TITLE
ci: enforce no-secrets (gitleaks); pre-commit py_compile hook

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,26 @@
+name: Secret scan (gitleaks)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+[extend]
+# Start from gitleaks defaults and add small repo-specific allowlists.
+
+[allowlist]
+description = "Allowlist common false positives"
+paths = [
+  # Academic/personal file is ignored; keep it out of scanning noise.
+  "cursor-memory-complete-setup-guide.md",
+]
+
+# Allowlisted patterns (avoid false positives on docs describing env var names)
+regexes = [
+  # Mentioning env var names in docs/templates is OK
+  "OPENAI_API_KEY",
+  "GITHUB_TOKEN",
+  "GITHUB_PERSONAL_ACCESS_TOKEN",
+]
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: py-compile-repo-scripts
+        name: python -m py_compile (repo scripts)
+        entry: bash -lc 'python3 -m py_compile "$@"'
+        language: system
+        types: [python]
+        files: ^(scripts|pdf_mcp)/.*\.py$
+        stages: [pre-commit]
       - id: pdf-mcp-prepush-gates
         name: pdf-mcp pre-push gates (tests + smoke)
         entry: bash -lc "make prepush"


### PR DESCRIPTION
## Summary

What does this PR change and why?

## Scope

- **Feature/bug**:
- **Breaking change**: yes/no (if yes: link approval comment)
- **MCP tools changed**: list tool names or “none”

## Quality gates (required)

- [ ] `make test` passes locally
- [ ] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [ ] Tests added/updated for new behavior (`tests/`)
- [ ] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [ ] `README.md` updated (tool list / usage) if needed
- [ ] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [ ] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

Describe how you verified by invoking the MCP tools and re-reading outputs.

## Notes

Links to issues, meeting distillation issue, sample PDFs (private repo), etc.


