### PR TITLE
ci: add ruff lint/format gates (diff-only)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: Lint (ruff)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install deps (incl. ruff)
+        run: make install
+
+      - name: Ruff lint (diff-only)
+        run: |
+          . .venv/bin/activate
+          git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
+          FILES=$(git diff --name-only "origin/${{ github.base_ref }}...${{ github.sha }}" | grep -E '\\.py$' || true)
+          if [ -z "$FILES" ]; then echo "ruff: no changed python files"; exit 0; fi
+          ruff check $FILES
+
+      - name: Ruff format (check, diff-only)
+        run: |
+          . .venv/bin/activate
+          git fetch origin "${{ github.base_ref }}":"refs/remotes/origin/${{ github.base_ref }}" || true
+          # Only check python files changed in the PR.
+          FILES=$(git diff --name-only "origin/${{ github.base_ref }}...${{ github.sha }}" | grep -E '\\.py$' || true)
+          if [ -z "$FILES" ]; then echo "ruff-format: no changed python files"; exit 0; fi
+          ruff format --check $FILES
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,13 @@ repos:
       - id: check-json
       - id: check-merge-conflict
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.12
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
   - repo: local
     hooks:
       - id: py-compile-repo-scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pre-commit"]
+dev = ["pytest", "pre-commit", "ruff"]
 
 [build-system]
 requires = ["setuptools>=61"]
@@ -23,4 +23,18 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 include = ["pdf_mcp*"]
 exclude = ["PROJECT_MEMO*", "memories-and-kb*", "docs*", "scripts*", "tests*"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+#
+# We enforce linting incrementally:
+# - CI + pre-push run ruff on *changed files* to prevent regressions.
+# - Keep rule set small to avoid forcing repo-wide cleanup in one PR.
+select = ["F", "E9", "I"]
+
+[tool.ruff.format]
+quote-style = "double"
 


### PR DESCRIPTION
## Summary

What does this PR change and why?

## Scope

- **Feature/bug**:
- **Breaking change**: yes/no (if yes: link approval comment)
- **MCP tools changed**: list tool names or “none”

## Quality gates (required)

- [ ] `make test` passes locally
- [ ] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [ ] Tests added/updated for new behavior (`tests/`)
- [ ] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [ ] `README.md` updated (tool list / usage) if needed
- [ ] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [ ] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

Describe how you verified by invoking the MCP tools and re-reading outputs.

## Notes

Links to issues, meeting distillation issue, sample PDFs (private repo), etc.


