### PR TITLE
ci: fix release gate parsing for pyproject and changelog

### DIFF
--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -14,11 +14,32 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
+from typing import Any, Dict
 
 
 def _read_pyproject_version(pyproject_path: Path) -> str:
+    """
+    Read version from pyproject.toml.
+
+    Prefer TOML parsing (PEP 621: [project].version). Fall back to regex only if
+    TOML parsing is unavailable for some reason.
+    """
     text = pyproject_path.read_text(encoding="utf-8")
-    m = re.search(r'(?m)^version\\s*=\\s*\"([^\"]+)\"\\s*$', text)
+
+    # Python 3.11+ ships tomllib. CI runs 3.10+ but tomllib should exist on 3.11/3.12.
+    try:
+        import tomllib  # type: ignore
+
+        data: Dict[str, Any] = tomllib.loads(text)
+        project = data.get("project") or {}
+        version = project.get("version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    except Exception:
+        pass
+
+    # Fallback: accept both double and single quoted versions.
+    m = re.search(r"(?m)^version\\s*=\\s*['\\\"]([^'\\\"]+)['\\\"]\\s*$", text)
     if not m:
         raise RuntimeError("Could not find version in pyproject.toml")
     return m.group(1).strip()
@@ -26,7 +47,7 @@ def _read_pyproject_version(pyproject_path: Path) -> str:
 
 def _changelog_has_version(changelog: str, version: str) -> bool:
     # Match "## 1.2.3" or "## 1.2.3 - YYYY-MM-DD"
-    pat = re.compile(rf"(?m)^##\\s+{re.escape(version)}(\\s+-.*)?$")
+    pat = re.compile(rf"(?m)^##\s+{re.escape(version)}(\s+-.*)?$")
     return bool(pat.search(changelog))
 
 


### PR DESCRIPTION
## Summary

What does this PR change and why?

## Scope

- **Feature/bug**:
- **Breaking change**: yes/no (if yes: link approval comment)
- **MCP tools changed**: list tool names or “none”

## Quality gates (required)

- [ ] `make test` passes locally
- [ ] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [ ] Tests added/updated for new behavior (`tests/`)
- [ ] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [ ] `README.md` updated (tool list / usage) if needed
- [ ] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [ ] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

Describe how you verified by invoking the MCP tools and re-reading outputs.

## Notes

Links to issues, meeting distillation issue, sample PDFs (private repo), etc.


