### PR TITLE
feat: form creation, nonstandard fill, and tier3 tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project follows Keep a Changelog and Semantic Versioning.
 
 ## Unreleased
 
+## 0.5.0 - 2026-01-28
+
+### Added
+- `create_pdf_form`: create PDF files with standard AcroForm fields.
+- `fill_pdf_form_any`: fill standard and non-standard forms using label detection.
+- `add_highlight`: add highlight annotations by text or rectangle.
+- `add_date_stamp`: add date stamps as FreeText annotations.
+- `detect_pii_patterns`: detect common PII patterns (email, phone, SSN, credit cards).
+- Release runbook: added PR/branch hygiene SOP.
+
 ## 0.4.1 - 2026-01-27
 
 ### Added

--- a/PROJECT_MEMO/GLOBAL_CURSOR_INSTRUCTIONS.md
+++ b/PROJECT_MEMO/GLOBAL_CURSOR_INSTRUCTIONS.md
@@ -266,4 +266,4 @@ pdf-mcp-server/
 
 ---
 
-*Last updated: 2026-01-27 | Version: 0.4.1*
+*Last updated: 2026-01-28 | Version: 0.5.0*

--- a/PROJECT_MEMO/RELEASE_RUNBOOK.md
+++ b/PROJECT_MEMO/RELEASE_RUNBOOK.md
@@ -8,6 +8,7 @@ Canonical changelog: `CHANGELOG.md` (Keep a Changelog + SemVer).
 - `make smoke` passes (hard requirements)
 - hard requirements verified (see `docs/CURSOR_SMOKE_TEST.md`)
 - `README.md` + `CHANGELOG.md` updated and consistent
+- PRs/branches reviewed and cleaned (see "PR + branch hygiene" below)
 
 ## Tag-based release SOP (short)
 
@@ -40,6 +41,20 @@ git push origin main --tags
 6. GitHub Release:
 - Create a release for tag `vX.Y.Z`
 - Paste the `CHANGELOG.md` section for `X.Y.Z`
+
+## PR + branch hygiene (required before release)
+
+1. Review open PRs:
+   - Merge anything that is release-related and ready.
+   - Close PRs that are outdated or tied to previous releases.
+   - Keep PRs that are clearly a new feature, POC, or unrelated track.
+
+2. Review branches:
+   - Delete merged or stale branches that belong to prior releases.
+   - Keep branches that represent active or unrelated work (POC, new feature track).
+
+3. Keep a short audit trail:
+   - Note any kept branches/PRs with a short reason in the release notes or tracker.
 
 ## Pre-push automation (recommended)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF MCP Server
 
-**Version 0.4.1** | MCP server for PDF form filling, editing, OCR text extraction, table extraction, image extraction, link extraction, and batch processing.
+**Version 0.5.0** | MCP server for PDF form filling, editing, OCR text extraction, table extraction, image extraction, link extraction, and batch processing.
 
 Built with Python, `pypdf`, `fillpdf`, and `pymupdf` (AGPL).
 
@@ -100,14 +100,15 @@ Restart Cursor after saving.
 
 | Category | Tools | Description |
 |----------|-------|-------------|
-| **Form Handling** | 4 tools | Fill, clear, flatten PDF forms |
+| **Form Handling** | 6 tools | Fill, clear, flatten, and create PDF forms |
 | **Page Operations** | 6 tools | Merge, extract, rotate, reorder, insert, remove pages |
-| **Annotations** | 12 tools | Text, comments, watermarks, signatures, redaction, numbering |
+| **Annotations** | 14 tools | Text, comments, watermarks, signatures, redaction, numbering, highlights |
 | **Export** | 2 tools | Export PDF content to Markdown or JSON |
 | **OCR & Text** | 8 tools | Type detection, native/OCR extraction, confidence scores |
 | **Table Extraction** | 1 tool | Extract tables as structured data |
 | **Image Extraction** | 2 tools | Extract/analyze embedded images |
 | **Form Detection** | 1 tool | Auto-detect form fields in non-AcroForm PDFs |
+| **PII Detection** | 1 tool | Detect common PII patterns (email, phone, SSN, credit cards) |
 | **Link Extraction** | 1 tool | Extract URLs, hyperlinks, internal references |
 | **PDF Optimization** | 1 tool | Compress/reduce PDF file size |
 | **Barcode/QR Detection** | 1 tool | Detect and decode barcodes and QR codes |
@@ -120,8 +121,10 @@ Restart Cursor after saving.
 ### Form Handling
 - `get_pdf_form_fields(pdf_path)`: list fields and count.
 - `fill_pdf_form(input_path, output_path, data, flatten=False)`: fill fields; optional flatten.
+- `fill_pdf_form_any(input_path, output_path, data, flatten=False)`: fill standard or non-standard forms using label detection when needed.
 - `clear_pdf_form_fields(input_path, output_path, fields=None)`: clear values while keeping fields fillable.
 - `flatten_pdf(input_path, output_path)`: flatten forms/annotations.
+- `create_pdf_form(output_path, fields, page_size=None, pages=1)`: create a new PDF with AcroForm fields.
 
 ### Page Operations
 - `merge_pdfs(pdf_list, output_path)`: merge multiple PDFs.
@@ -139,6 +142,8 @@ Restart Cursor after saving.
 - `insert_text` / `edit_text` / `remove_text`: managed text via FreeText annotations.
 - `redact_text_regex(input_path, output_path, pattern, ...)`: redact text using a regex pattern.
 - `add_text_watermark(input_path, output_path, text, ...)`: add text watermark/stamp.
+- `add_highlight(input_path, output_path, page, text=None, rect=None)`: add highlight annotations.
+- `add_date_stamp(input_path, output_path, ...)`: add a date stamp.
 - `add_page_numbers(input_path, output_path, ...)`: add page numbers as annotations.
 - `add_bates_numbering(input_path, output_path, ...)`: add Bates numbering as annotations.
 - `add_comment` / `update_comment` / `remove_comment`: PDF comments (sticky notes).
@@ -180,6 +185,9 @@ Restart Cursor after saving.
 
 ### Form Auto-Detection
 - `detect_form_fields(pdf_path, pages=None)`: detect potential form fields in non-AcroForm PDFs using text pattern analysis (labels, checkboxes, underlines).
+
+### PII Detection
+- `detect_pii_patterns(pdf_path, pages=None)`: detect common PII patterns (email, phone, SSN, credit cards).
 
 ### Link Extraction (Phase 3)
 - `extract_links(pdf_path, pages=None)`: extract URLs, hyperlinks, and internal references with type categorization.
@@ -242,7 +250,7 @@ make prepush
 ```
 
 ### Test Coverage
-- **159 tests** total (includes Tier 1/2 coverage)
+- **164 tests** total (includes Tier 1/2 coverage)
 - All tests pass with Tesseract installed
 - 3 tests skip when optional dependencies (Tesseract/pyzbar) are not available
 

--- a/pdf_mcp/server.py
+++ b/pdf_mcp/server.py
@@ -5,17 +5,19 @@ This module exposes PDF tools via the MCP protocol for use with AI assistants.
 Run with: python -m pdf_mcp.server
 
 Available tool categories:
-- Form handling (4 tools)
+- Form handling (6 tools)
 - Page operations (6 tools)
-- Annotations & text (12 tools)
+- Annotations & text (14 tools)
 - Signatures & security (5 tools)
 - Metadata (4 tools)
 - Export (2 tools)
 - OCR & text extraction (8 tools)
 - Table/image extraction (3 tools)
 - Form detection (1 tool)
+- PII detection (1 tool)
+ - PII detection (1 tool)
 
-Version: 0.4.1
+Version: 0.5.0
 License: AGPL-3.0
 """
 from __future__ import annotations
@@ -69,6 +71,30 @@ def fill_pdf_form(
 ) -> Dict[str, Any]:
     """Fill a PDF form with provided data. Optionally flatten to make non-editable."""
     return pdf_tools.fill_pdf_form(input_path, output_path, data, flatten)
+
+
+@mcp.tool()
+@_handle_errors
+def fill_pdf_form_any(
+    input_path: str,
+    output_path: str,
+    data: Dict[str, Any],
+    flatten: bool = False,
+) -> Dict[str, Any]:
+    """Fill standard or non-standard forms using label detection when needed."""
+    return pdf_tools.fill_pdf_form_any(input_path, output_path, data, flatten)
+
+
+@mcp.tool()
+@_handle_errors
+def create_pdf_form(
+    output_path: str,
+    fields: List[Dict[str, Any]],
+    page_size: Optional[Sequence[float]] = None,
+    pages: int = 1,
+) -> Dict[str, Any]:
+    """Create a new PDF with AcroForm fields."""
+    return pdf_tools.create_pdf_form(output_path, fields, page_size=page_size, pages=pages)
 
 
 @mcp.tool()
@@ -465,6 +491,50 @@ def add_text_watermark(
 
 @mcp.tool()
 @_handle_errors
+def add_highlight(
+    input_path: str,
+    output_path: str,
+    page: int,
+    text: Optional[str] = None,
+    rect: Optional[Sequence[float]] = None,
+) -> Dict[str, Any]:
+    """Add highlight annotations by text search or rectangle."""
+    return pdf_tools.add_highlight(
+        input_path=input_path,
+        output_path=output_path,
+        page=page,
+        text=text,
+        rect=rect,
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def add_date_stamp(
+    input_path: str,
+    output_path: str,
+    pages: Optional[List[int]] = None,
+    position: str = "bottom-right",
+    margin: float = 20,
+    width: float = 120,
+    height: float = 20,
+    date_text: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Add a date stamp as a FreeText annotation."""
+    return pdf_tools.add_date_stamp(
+        input_path=input_path,
+        output_path=output_path,
+        pages=pages,
+        position=position,
+        margin=margin,
+        width=width,
+        height=height,
+        date_text=date_text,
+    )
+
+
+@mcp.tool()
+@_handle_errors
 def add_comment(
     input_path: str,
     output_path: str,
@@ -818,6 +888,18 @@ def detect_form_fields(
     Useful for PDFs that appear to be forms but don't have AcroForm fields.
     """
     return pdf_tools.detect_form_fields(pdf_path, pages=pages)
+
+
+@mcp.tool()
+@_handle_errors
+def detect_pii_patterns(
+    pdf_path: str,
+    pages: Optional[List[int]] = None,
+) -> Dict[str, Any]:
+    """
+    Detect common PII patterns (email, phone, SSN, credit card) in a PDF.
+    """
+    return pdf_tools.detect_pii_patterns(pdf_path, pages=pages)
 
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-mcp"
-version = "0.4.1"
+version = "0.5.0"
 description = "Local MCP server for PDF form filling, editing, and OCR text extraction"
 authors = [{ name = "Local User" }]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Add AcroForm creation, non-standard form filling, and Tier 3 annotation/PII tools with tests and docs updates for the next release.

## Scope

- **Feature/bug**: feature
- **Breaking change**: no
- **MCP tools changed**: `create_pdf_form`, `fill_pdf_form_any`, `add_highlight`, `add_date_stamp`, `detect_pii_patterns`

## Quality gates (required)

- [x] `make test` passes locally
- [ ] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [x] Tests added/updated for new behavior (`tests/`)
- [x] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [x] `README.md` updated (tool list / usage) if needed
- [x] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [x] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

- Not run (test suite covers new tools)

## Notes

- Full test run: `make test`
