### PR TITLE
feat: add certificate-based PDF signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows Keep a Changelog and Semantic Versioning.
 
 ## Unreleased
 
+## 0.5.1 - 2026-01-28
+
+### Added
+- `sign_pdf`: digitally sign PDFs using PKCS#12/PFX certificates.
+- `sign_pdf_pem`: digitally sign PDFs using PEM key + cert chain.
+- Integration tests for certificate-based signing.
+- `cryptography` dependency for test certificate generation.
+
 ## 0.5.0 - 2026-01-28
 
 ### Added

--- a/PROJECT_MEMO/GLOBAL_CURSOR_INSTRUCTIONS.md
+++ b/PROJECT_MEMO/GLOBAL_CURSOR_INSTRUCTIONS.md
@@ -150,6 +150,7 @@ With 300+ MCP tools available, use this quick guide:
 - Use feature branches off `main`
 - Keep PRs focused (single tool/capability + tests)
 - Delete merged branches and run `git fetch --prune`
+- Before releases, review/close outdated PRs and delete stale branches (keep active POCs/features)
 
 ### Tag-based release (SemVer)
 
@@ -266,4 +267,4 @@ pdf-mcp-server/
 
 ---
 
-*Last updated: 2026-01-28 | Version: 0.5.0*
+*Last updated: 2026-01-28 | Version: 0.5.1*

--- a/PROJECT_MEMO/MEMORY_AND_RULES.md
+++ b/PROJECT_MEMO/MEMORY_AND_RULES.md
@@ -26,6 +26,11 @@ Cursor has its own memory system and MCP tooling. This repo keeps a portable, re
 2) Use absolute paths for inputs and outputs.
 3) Test each tool with a small dummy PDF and verify output by reopening it.
 
+## Release checklist hygiene (must)
+
+- Review open PRs/branches before release; merge or close outdated ones.
+- Delete stale branches tied to past releases unless they are active POCs or new feature tracks.
+
 ## Open source hygiene
 
 - Files like `cursor-memory-complete-setup-guide.md` must remain untracked and ignored.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF MCP Server
 
-**Version 0.5.0** | MCP server for PDF form filling, editing, OCR text extraction, table extraction, image extraction, link extraction, and batch processing.
+**Version 0.5.1** | MCP server for PDF form filling, editing, OCR text extraction, table extraction, image extraction, link extraction, and batch processing.
 
 Built with Python, `pypdf`, `fillpdf`, and `pymupdf` (AGPL).
 
@@ -103,6 +103,7 @@ Restart Cursor after saving.
 | **Form Handling** | 6 tools | Fill, clear, flatten, and create PDF forms |
 | **Page Operations** | 6 tools | Merge, extract, rotate, reorder, insert, remove pages |
 | **Annotations** | 14 tools | Text, comments, watermarks, signatures, redaction, numbering, highlights |
+| **Signatures & Security** | 7 tools | Digital signing, verification, encryption |
 | **Export** | 2 tools | Export PDF content to Markdown or JSON |
 | **OCR & Text** | 8 tools | Type detection, native/OCR extraction, confidence scores |
 | **Table Extraction** | 1 tool | Extract tables as structured data |
@@ -152,6 +153,8 @@ Restart Cursor after saving.
 - `add_signature_image(input_path, output_path, page, image_path, rect)`: add signature image.
 - `update_signature_image(...)`: update or resize signature.
 - `remove_signature_image(...)`: remove signature image.
+- `sign_pdf(input_path, output_path, pfx_path, ...)`: digitally sign PDF using PKCS#12/PFX.
+- `sign_pdf_pem(input_path, output_path, key_path, cert_path, ...)`: digitally sign PDF using PEM key + cert chain.
 - `encrypt_pdf(input_path, output_path, user_password, ...)`: password-protect PDF.
 - `verify_digital_signatures(pdf_path)`: verify digital signatures.
 
@@ -250,7 +253,7 @@ make prepush
 ```
 
 ### Test Coverage
-- **164 tests** total (includes Tier 1/2 coverage)
+- **166 tests** total (includes Tier 1/2 coverage)
 - All tests pass with Tesseract installed
 - 3 tests skip when optional dependencies (Tesseract/pyzbar) are not available
 

--- a/pdf_mcp/server.py
+++ b/pdf_mcp/server.py
@@ -8,7 +8,7 @@ Available tool categories:
 - Form handling (6 tools)
 - Page operations (6 tools)
 - Annotations & text (14 tools)
-- Signatures & security (5 tools)
+- Signatures & security (7 tools)
 - Metadata (4 tools)
 - Export (2 tools)
 - OCR & text extraction (8 tools)
@@ -17,7 +17,7 @@ Available tool categories:
 - PII detection (1 tool)
  - PII detection (1 tool)
 
-Version: 0.5.0
+Version: 0.5.1
 License: AGPL-3.0
 """
 from __future__ import annotations
@@ -466,6 +466,60 @@ def add_bates_numbering(
 def verify_digital_signatures(pdf_path: str) -> Dict[str, Any]:
     """Verify digital signatures in a PDF."""
     return pdf_tools.verify_digital_signatures(pdf_path)
+
+
+@mcp.tool()
+@_handle_errors
+def sign_pdf(
+    input_path: str,
+    output_path: str,
+    pfx_path: str,
+    pfx_password: Optional[str] = None,
+    field_name: str = "Signature1",
+    certify: bool = True,
+    reason: Optional[str] = None,
+    location: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Digitally sign a PDF using a PKCS#12/PFX certificate."""
+    return pdf_tools.sign_pdf(
+        input_path=input_path,
+        output_path=output_path,
+        pfx_path=pfx_path,
+        pfx_password=pfx_password,
+        field_name=field_name,
+        certify=certify,
+        reason=reason,
+        location=location,
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def sign_pdf_pem(
+    input_path: str,
+    output_path: str,
+    key_path: str,
+    cert_path: str,
+    chain_paths: Optional[List[str]] = None,
+    key_password: Optional[str] = None,
+    field_name: str = "Signature1",
+    certify: bool = True,
+    reason: Optional[str] = None,
+    location: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Digitally sign a PDF using PEM key + cert chain."""
+    return pdf_tools.sign_pdf_pem(
+        input_path=input_path,
+        output_path=output_path,
+        key_path=key_path,
+        cert_path=cert_path,
+        chain_paths=chain_paths,
+        key_password=key_password,
+        field_name=field_name,
+        certify=certify,
+        reason=reason,
+        location=location,
+    )
 
 
 @mcp.tool()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local MCP server for PDF form filling, editing, and OCR text extraction"
 authors = [{ name = "Local User" }]
 requires-python = ">=3.10"
@@ -10,6 +10,7 @@ dependencies = [
     "fillpdf>=0.7.3",
     "pymupdf>=1.26.7",
     "pyhanko>=0.32.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Add certificate-based PDF signing (PKCS#12 and PEM), update SOP/memo hygiene, and add integration tests.

## Scope

- **Feature/bug**: feature
- **Breaking change**: no
- **MCP tools changed**: `sign_pdf`, `sign_pdf_pem`

## Quality gates (required)

- [x] `make test` passes locally
- [x] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [x] Tests added/updated for new behavior (`tests/`)
- [x] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [x] `README.md` updated (tool list / usage) if needed
- [x] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [x] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

- `sign_pdf` + `sign_pdf_pem` exercised via `tests/test_pdf_tools.py`

## Notes

- Uses `cryptography` for test cert generation
