### PR TITLE
update: prefer MCP tools first in rules

### DIFF
--- a/.cursor/rules/memory-system.rules
+++ b/.cursor/rules/memory-system.rules
@@ -43,6 +43,10 @@ Your system has three memory layers that work together automatically:
 | Procedure or guide discovered | Update Pepper only | Layer 2 |
 | Investigation completed | Write to global-kb/ | Layer 3 |
 
+## Tool Usage Priority
+
+- Prefer MCP tools first for relevant operations; use shell only when no suitable MCP tool exists.
+
 ### Quality Gates (Before Creating Cursor Memory)
 
 1. Is this needed every conversation?


### PR DESCRIPTION
## Summary

Add a workspace rule to prefer MCP tools first for relevant operations.

## Scope

- **Feature/bug**: feature
- **Breaking change**: no
- **MCP tools changed**: none

## Quality gates (required)

- [ ] `make test` passes locally
- [ ] `./.venv/bin/python scripts/cursor_smoke.py` passes (extend if needed)
- [ ] Tests added/updated for new behavior (`tests/`)
- [ ] No secrets added (repo stays open-source safe)

## Docs / release hygiene

- [ ] `README.md` updated (tool list / usage) if needed
- [ ] `CHANGELOG.md` updated under **Unreleased** if user-facing change
- [ ] `PROJECT_MEMO/` updated if workflow/runbook changed

## Manual verification (Cursor-style)

Not applicable (rules-only change).

## Notes

Rule added in `.cursor/rules/memory-system.rules`.
