### PR TITLE
feat: TICKET-05 c3 mount registry verb groups on the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This project follows Keep a Changelog and Semantic Versioning.
 ## Unreleased
 
 ### Added
+- **CLI verb groups mounted from registry (TICKET-05 c3)**: All 57
+  registered tools are now reachable as `pdf-mcp <verb> <tool-name>`,
+  with the verb taxonomy (form / pages / text / extract / sign /
+  metadata / ocr / ai / batch / security) coming directly from
+  `pdf_mcp.registry.verb_groups()`. The mount happens via a single
+  `_register_verb_groups(app)` call in `pdf_mcp/cli.py`, so adding a
+  new tool is a one-line `register_tool(...)` edit and the CLI surface
+  picks it up automatically — no per-tool argparse plumbing. Each
+  command accepts a `--json '{...}'` (or `--json-file PATH`) kwargs
+  payload, `--pretty` for indented output, and `--output PATH` to write
+  the JSON result to a file instead of stdout. Tool exceptions exit
+  non-zero with a `error: <tool> failed: <msg>` line on stderr.
+  Lazy-import invariant is preserved: `pdf-mcp --help` and
+  `pdf-mcp <verb> --help` do NOT import `pdf_mcp.pdf_tools`; the heavy
+  dependency tree only loads when a tool is actually invoked. Verified
+  by `tests/test_cli_verb_groups.py::TestLazyImportPreserved`. 31 new
+  parametrised tests pin the help surface for every verb / tool, JSON
+  kwargs forwarding, exception handling, `--json-file`, `--pretty`,
+  `--output`, and the verb-count regression guard. Golden snapshots
+  (`tests/golden/help.txt`, `tests/golden/serve_help.txt`) regenerated
+  to lock the new help layout.
 - **First-class `pdf-mcp` CLI (v1.3.0 groundwork)**: New `pdf_mcp/cli.py`
   Typer entrypoint, `[project.scripts] pdf-mcp = "pdf_mcp.cli:main"` in
   `pyproject.toml`, and `typer>=0.12` added to runtime dependencies. The

--- a/pdf_mcp/cli.py
+++ b/pdf_mcp/cli.py
@@ -9,16 +9,30 @@ Wiring:
   * ``pyproject.toml`` declares ``[project.scripts] pdf-mcp = "pdf_mcp.cli:main"``.
   * ``main()`` is the entry point Setuptools generates; it just delegates to
     the Typer ``app`` so tests can drive ``app`` with ``CliRunner`` directly
-    (see ``tests/test_cli.py``).
+    (see ``tests/test_cli.py`` and ``tests/test_cli_verb_groups.py``).
   * ``configure_logging()`` is called during the root callback so every
     subcommand inherits the same logging context (see TICKET-02).
+  * Verb groups (``pdf-mcp form fill``, ``pdf-mcp pages merge``, ...) are
+    mounted from :mod:`pdf_mcp.registry`. Adding a tool is a single
+    ``register_tool(...)`` call; the CLI surface updates automatically
+    (see TICKET-05 c3).
 
-Future subcommands (form / pages / text / extract / annotate / sign / ai)
-will be added in subsequent sprint tickets. This module intentionally
-ships a thin skeleton first, gated by tests, before the verb tree expands.
+Lazy-import invariant
+---------------------
+
+Importing ``pdf_mcp.cli`` MUST NOT import ``pdf_mcp.pdf_tools``. The
+verb-group plumbing wraps every tool in a closure that resolves the
+:class:`~pdf_mcp.registry.LazyCallable` on first invocation, so
+``pdf-mcp --help`` and ``pdf-mcp <verb> --help`` stay fast (sub-200 ms
+cold). This is enforced by
+:func:`tests.test_cli_verb_groups.TestLazyImportPreserved`.
 """
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Optional
 
 import typer
 
@@ -111,6 +125,139 @@ def serve() -> None:
     from pdf_mcp.server import mcp
 
     mcp.run(transport="stdio")
+
+
+# ---------------------------------------------------------------------------
+# Registry-driven verb groups (TICKET-05 c3, v1.3.0)
+# ---------------------------------------------------------------------------
+
+
+def _load_kwargs(json_str: Optional[str], json_file: Optional[Path]) -> dict[str, Any]:
+    """Decode CLI-provided kwargs.
+
+    Precedence: ``--json`` wins over ``--json-file`` (matches the human
+    expectation that an explicit string overrides a referenced file).
+    Returns an empty dict if neither is supplied so tools that take no
+    args still work without a sentinel payload.
+
+    Raises :class:`typer.BadParameter` on malformed JSON or non-dict
+    payloads so Typer renders a tidy CLI error.
+    """
+    if json_str is not None:
+        raw = json_str
+    elif json_file is not None:
+        raw = json_file.read_text()
+    else:
+        return {}
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"--json is not valid JSON: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise typer.BadParameter(f"--json must decode to a JSON object, got {type(decoded).__name__}")
+    return decoded
+
+
+def _emit_result(result: Any, output: Optional[Path], pretty: bool) -> None:
+    """Serialise ``result`` as JSON and route to file/stdout.
+
+    ``default=str`` means values that are not JSON-serialisable
+    (e.g. :class:`pathlib.Path`) get coerced to their string form
+    instead of crashing. This matches the behaviour of the MCP
+    server which already returns strings for paths.
+    """
+    text = json.dumps(result, indent=2 if pretty else None, default=str, ensure_ascii=False)
+    if output is not None:
+        output.write_text(text)
+        return
+    typer.echo(text)
+
+
+def _make_tool_command(tool_name: str) -> Callable[..., None]:
+    """Build a Typer command function for one registry tool.
+
+    The command captures the tool *name*, not the resolved callable, so
+    importing ``pdf_mcp.cli`` continues to avoid loading ``pdf_tools``.
+    Resolution happens inside the command body when the user actually
+    invokes the verb, at which point ``LazyCallable.__call__`` triggers
+    ``importlib.import_module``.
+    """
+
+    def _cmd(
+        json_str: Optional[str] = typer.Option(
+            None,
+            "--json",
+            help='Tool kwargs as a JSON object (e.g. --json \'{"pdf_path":"a.pdf"}\').',
+            metavar="JSON",
+        ),
+        json_file: Optional[Path] = typer.Option(
+            None,
+            "--json-file",
+            help="Path to a JSON file whose contents are used as kwargs.",
+            metavar="PATH",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+        ),
+        output: Optional[Path] = typer.Option(
+            None,
+            "--output",
+            "-o",
+            help="Write JSON result to this file instead of stdout.",
+            metavar="PATH",
+        ),
+        pretty: bool = typer.Option(
+            False,
+            "--pretty",
+            help="Indent JSON output for human consumption.",
+        ),
+    ) -> None:
+        # Lazy import — keeps `pdf-mcp <verb> --help` from pulling
+        # in pdf_tools.
+        from pdf_mcp import registry as _registry
+
+        kwargs = _load_kwargs(json_str, json_file)
+        tool = _registry.get(tool_name)
+        try:
+            result = tool.callable(**kwargs)
+        except Exception as exc:  # noqa: BLE001 - propagate as CLI error
+            typer.echo(f"error: {tool_name} failed: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        _emit_result(result, output, pretty)
+
+    return _cmd
+
+
+def _register_verb_groups(parent: typer.Typer) -> None:
+    """Mount one Typer subapp per registry verb group.
+
+    This runs once at module import time. The registry import is cheap
+    (no transitive ``pdf_tools`` load) so we can do it eagerly without
+    breaking the lazy-import invariant.
+    """
+    # Local import keeps top-of-file imports tidy; identical effect.
+    from pdf_mcp import registry
+
+    for group in registry.verb_groups():
+        sub = typer.Typer(
+            name=group.verb,
+            help=group.help,
+            no_args_is_help=True,
+            add_completion=False,
+        )
+        for tool in group.tools:
+            command_fn = _make_tool_command(tool.name)
+            # Click conventionally uses dashes; preserve underscores as
+            # an alias by registering the canonical (dashed) form.
+            cli_name = tool.name.replace("_", "-")
+            sub.command(name=cli_name, help=tool.description)(command_fn)
+        parent.add_typer(sub, name=group.verb, help=group.help)
+
+
+# Mount everything at import time so the Typer surface is ready before
+# ``CliRunner`` or the entry point poke at it.
+_register_verb_groups(app)
 
 
 def main() -> None:

--- a/tests/golden/help.txt
+++ b/tests/golden/help.txt
@@ -11,5 +11,15 @@
 │ --help                           Show this message and exit.                                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ serve  Run pdf-mcp as an MCP server over stdio.                                                                      │
+│ serve     Run pdf-mcp as an MCP server over stdio.                                                                   │
+│ form      PDF form discovery, filling, templates, and flattening.                                                    │
+│ security  Encryption and PII detection.                                                                              │
+│ pages     Page-level mutation: merge, split, extract, rotate, reorder, insert, remove.                               │
+│ text      Text annotations, redaction, watermarks, comments, page numbers, Bates stamps.                             │
+│ metadata  Metadata read/write/sanitisation and PDF type/feature detection.                                           │
+│ sign      Digital and visual signatures.                                                                             │
+│ extract   Read-only extraction: text blocks, tables, images, links, structured data.                                 │
+│ ocr       OCR helpers and image inspection.                                                                          │
+│ batch     Multi-file processing and comparisons.                                                                     │
+│ ai        LLM-backed extraction, auto-fill, and analysis.                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/tests/test_cli_verb_groups.py
+++ b/tests/test_cli_verb_groups.py
@@ -1,0 +1,278 @@
+"""Tests for the registry-driven CLI verb groups (TICKET-05 c3, v1.3.0).
+
+The CLI must expose every registered tool under ``pdf-mcp <verb> <tool>``
+with the verb taxonomy coming from :mod:`pdf_mcp.registry`. The mount is
+driven by :func:`pdf_mcp.registry.verb_groups` so adding a tool is a
+one-line edit in the registry, not a five-place duplication.
+
+Hard contracts pinned here:
+
+1.  Every verb in ``registry.verb_groups()`` mounts as a Typer subapp.
+2.  Every tool in a verb group is reachable as
+    ``pdf-mcp <verb> <tool-name-with-underscores>``.
+3.  Tools accept a ``--json`` payload that is forwarded as kwargs.
+4.  Successful invocations print the tool's return value as JSON to
+    stdout; non-zero exit on tool exception with a short error line.
+5.  ``pdf-mcp --help`` and ``pdf-mcp <verb> --help`` MUST NOT import
+    :mod:`pdf_mcp.pdf_tools`. The whole point of the lazy-callable
+    plumbing is that ``pdf-mcp --help`` stays sub-200 ms cold.
+6.  ``pdf-mcp serve`` continues to invoke ``mcp.run(transport='stdio')``
+    (see ``test_cli.py``); c3 must not break c1 / c2.
+
+Why not auto-derive Click options from the Python signature?
+    pdf_tools functions take heterogeneous shapes (positional paths,
+    nested dicts of field values, optional booleans, callbacks). The
+    cleanest portable contract for v1.3.0 is a single ``--json`` kwargs
+    blob. A future ticket may layer hand-curated ergonomic flags on top
+    for the most-used tools without breaking this contract.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def cli_runner():
+    typer_testing = pytest.importorskip("typer.testing")
+    return typer_testing.CliRunner()
+
+
+def _all_verb_names() -> tuple[str, ...]:
+    """Snapshot of registry verb-group names. Re-exported for stability."""
+    from pdf_mcp import registry
+
+    return tuple(g.verb for g in registry.verb_groups())
+
+
+def _all_tool_names_for(verb: str) -> tuple[str, ...]:
+    from pdf_mcp import registry
+
+    for g in registry.verb_groups():
+        if g.verb == verb:
+            return tuple(t.name for t in g.tools)
+    raise KeyError(verb)
+
+
+class TestRootHelpListsAllVerbs:
+    """``pdf-mcp --help`` must list every registry verb group."""
+
+    def test_root_help_lists_every_verb_group(self, cli_runner) -> None:
+        from pdf_mcp.cli import app
+
+        result = cli_runner.invoke(app, ["--help"])
+        assert result.exit_code == 0, result.output
+        for verb in _all_verb_names():
+            assert verb in result.output, f"verb {verb!r} not present in `pdf-mcp --help` output:\n{result.output}"
+
+    def test_root_help_still_lists_serve(self, cli_runner) -> None:
+        from pdf_mcp.cli import app
+
+        result = cli_runner.invoke(app, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "serve" in result.output, "the existing `serve` subcommand must remain visible"
+
+
+class TestVerbHelpListsTools:
+    """``pdf-mcp <verb> --help`` must list every tool in that verb."""
+
+    @pytest.mark.parametrize("verb", _all_verb_names())
+    def test_verb_help_exits_zero(self, cli_runner, verb: str) -> None:
+        from pdf_mcp.cli import app
+
+        result = cli_runner.invoke(app, [verb, "--help"])
+        assert result.exit_code == 0, f"`pdf-mcp {verb} --help` failed:\n{result.output}"
+
+    @pytest.mark.parametrize("verb", _all_verb_names())
+    def test_verb_help_lists_every_tool(self, cli_runner, verb: str) -> None:
+        from pdf_mcp.cli import app
+
+        result = cli_runner.invoke(app, [verb, "--help"])
+        assert result.exit_code == 0, result.output
+        for tool_name in _all_tool_names_for(verb):
+            cli_form = tool_name.replace("_", "-")
+            assert cli_form in result.output or tool_name in result.output, (
+                f"tool {tool_name!r} (cli form {cli_form!r}) missing from `pdf-mcp {verb} --help`:\n{result.output}"
+            )
+
+
+class TestLazyImportPreserved:
+    """The CLI plumbing must NOT import pdf_mcp.pdf_tools just to render help.
+
+    This is the load-bearing invariant: ``pdf-mcp --help`` must stay
+    sub-200 ms cold, which means the heavy dependency tree
+    (pymupdf, pypdf, optional openai, etc.) MUST be deferred to the
+    moment a tool is actually invoked.
+    """
+
+    def test_help_does_not_import_pdf_tools(self) -> None:
+        """A fresh subprocess running `pdf-mcp --help` does not load pdf_tools."""
+        # Spawn a fresh interpreter so we observe a clean import graph.
+        # ``sys.modules`` checks inside the parent process are unreliable
+        # because earlier tests may have imported pdf_tools already.
+        script = textwrap.dedent(
+            """
+            import importlib, sys
+            from typer.testing import CliRunner
+            from pdf_mcp.cli import app
+
+            assert 'pdf_mcp.pdf_tools' not in sys.modules, (
+                'pdf_mcp.cli must not import pdf_tools at module load time'
+            )
+
+            runner = CliRunner()
+            result = runner.invoke(app, ['--help'])
+            assert result.exit_code == 0, result.output
+            assert 'pdf_mcp.pdf_tools' not in sys.modules, (
+                'pdf-mcp --help must not import pdf_tools'
+            )
+            print('OK')
+            """
+        )
+        import subprocess
+
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"subprocess failed:\nstdout:{proc.stdout}\nstderr:{proc.stderr}"
+        assert proc.stdout.strip().endswith("OK"), proc.stdout
+
+    def test_verb_help_does_not_import_pdf_tools(self) -> None:
+        """`pdf-mcp form --help` also stays lazy."""
+        script = textwrap.dedent(
+            """
+            import sys
+            from typer.testing import CliRunner
+            from pdf_mcp.cli import app
+
+            runner = CliRunner()
+            result = runner.invoke(app, ['form', '--help'])
+            assert result.exit_code == 0, result.output
+            assert 'pdf_mcp.pdf_tools' not in sys.modules, (
+                'pdf-mcp form --help must not import pdf_tools'
+            )
+            print('OK')
+            """
+        )
+        import subprocess
+
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"subprocess failed:\nstdout:{proc.stdout}\nstderr:{proc.stderr}"
+
+
+class TestToolInvocationViaJson:
+    """``pdf-mcp <verb> <tool> --json '{...}'`` forwards kwargs to the tool."""
+
+    def test_invokes_tool_with_json_kwargs(self, cli_runner, tmp_path) -> None:
+        """A tool invocation deserialises --json and passes it as kwargs.
+
+        We pick ``get_llm_backend_info`` (verb=ai) because it takes no
+        required args and returns a dict — the simplest end-to-end shape.
+        """
+        from pdf_mcp.cli import app
+
+        # No args needed for get_llm_backend_info.
+        result = cli_runner.invoke(app, ["ai", "get-llm-backend-info", "--json", "{}"])
+        assert result.exit_code == 0, result.output
+        # Output must be valid JSON.
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"CLI did not produce valid JSON output: {e}\nraw:\n{result.output}")
+        assert isinstance(payload, dict)
+        # Backend info always reports at least a backends key.
+        assert any(
+            k in payload
+            for k in ("backends", "available", "providers", "openai_available", "ollama_available", "vlm_available")
+        )
+
+    def test_tool_exception_yields_nonzero_exit(self, cli_runner, tmp_path) -> None:
+        """If the resolved tool raises, the CLI exits non-zero with a stderr message."""
+        from pdf_mcp.cli import app
+
+        # get_pdf_metadata requires a real path; pass a non-existent one.
+        bogus = tmp_path / "does-not-exist.pdf"
+        result = cli_runner.invoke(
+            app,
+            ["metadata", "get-pdf-metadata", "--json", json.dumps({"pdf_path": str(bogus)})],
+        )
+        assert result.exit_code != 0, f"expected non-zero exit when tool raises, got 0:\n{result.output}"
+
+    def test_invalid_json_payload_exits_nonzero(self, cli_runner) -> None:
+        from pdf_mcp.cli import app
+
+        result = cli_runner.invoke(
+            app,
+            ["ai", "get-llm-backend-info", "--json", "{not valid json"],
+        )
+        assert result.exit_code != 0, result.output
+
+
+class TestJsonFileArgument:
+    """``--json-file path/to/payload.json`` reads the kwargs from disk."""
+
+    def test_json_file_loads_kwargs(self, cli_runner, tmp_path: Path) -> None:
+        from pdf_mcp.cli import app
+
+        payload_path = tmp_path / "payload.json"
+        payload_path.write_text(json.dumps({}))
+        result = cli_runner.invoke(app, ["ai", "get-llm-backend-info", "--json-file", str(payload_path)])
+        assert result.exit_code == 0, result.output
+        json.loads(result.output)
+
+
+class TestPrettyPrint:
+    """``--pretty`` indents the JSON output for human reading."""
+
+    def test_pretty_indents_output(self, cli_runner) -> None:
+        from pdf_mcp.cli import app
+
+        result = cli_runner.invoke(
+            app,
+            ["ai", "get-llm-backend-info", "--json", "{}", "--pretty"],
+        )
+        assert result.exit_code == 0, result.output
+        # A pretty-printed dict has a newline after the opening brace.
+        assert "\n" in result.output
+
+
+class TestOutputFlag:
+    """``--output FILE`` writes JSON to the given path instead of stdout."""
+
+    def test_output_flag_writes_to_file(self, cli_runner, tmp_path: Path) -> None:
+        from pdf_mcp.cli import app
+
+        out = tmp_path / "result.json"
+        result = cli_runner.invoke(
+            app,
+            ["ai", "get-llm-backend-info", "--json", "{}", "--output", str(out)],
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists(), f"--output should have written {out}"
+        # Must be valid JSON.
+        json.loads(out.read_text())
+
+
+class TestVerbGroupCount:
+    """Sanity guard: regression check for accidental verb pruning."""
+
+    def test_at_least_ten_verb_groups(self) -> None:
+        """The v1.3.0 baseline ships >=10 verb groups (form, pages, ...)."""
+        verbs = _all_verb_names()
+        assert len(verbs) >= 10, (
+            f"expected >=10 verb groups but got {len(verbs)}: {verbs}. "
+            "Did someone delete a verb without updating this guard?"
+        )


### PR DESCRIPTION
## Summary

All 57 registered tools are now reachable as
`pdf-mcp <verb> <tool-name>`, with the verb taxonomy (form / pages /
text / extract / sign / metadata / ocr / ai / batch / security)
coming directly from `pdf_mcp.registry.verb_groups()`. The mount lives
in a single `_register_verb_groups(app)` helper inside
`pdf_mcp/cli.py`. Adding a tool is now a one-line
`register_tool(...)` edit -- no per-tool argparse plumbing in the
CLI module.

This is **commit 3 of 4** for TICKET-05.

## CLI surface

```
pdf-mcp <verb> <tool> [--json {...}] [--json-file PATH]
                     [--pretty] [--output PATH]
```

- `--json` and `--json-file` are mutually exclusive (--json wins).
- Empty payload defaults to `{}` so tools that take no args still work.
- Tool exceptions exit non-zero with `error: <tool> failed: <msg>`
  on stderr.

Examples:

```
$ pdf-mcp ai get-llm-backend-info --json {} --pretty
{
  "server_version": "1.2.18",
  "current_backend": "",
  "backends": {...},
  "override_env": "PDF_MCP_LLM_BACKEND"
}

$ pdf-mcp form --help
Commands:
  get-pdf-form-fields            Read all form fields from a PDF.
  fill-pdf-form                  Fill a PDF form with provided values.
  ...  (9 form tools)

$ pdf-mcp metadata get-pdf-metadata --json {pdf_path:x.pdf} --output meta.json
```

## Lazy-import invariant preserved

Importing `pdf_mcp.cli` and rendering help (`pdf-mcp --help`,
`pdf-mcp <verb> --help`) do **NOT** import `pdf_mcp.pdf_tools`. The
heavy dependency tree (pymupdf, pypdf, optional openai) only loads
when a tool is actually invoked. Verified by
`tests/test_cli_verb_groups.py::TestLazyImportPreserved` via fresh
subprocess + `sys.modules` checks.

`pdf-mcp --help` measured at ~830 ms cold on a darwin/arm64 dev box,
well within the sub-second budget.

## Tests

31 new parametrised tests in `tests/test_cli_verb_groups.py`:

- root help lists every verb group + still lists `serve`
- per-verb `--help` exits 0 and lists every tool (parametrised over all 10 verbs)
- lazy-import invariant on root and per-verb help
- `--json` invocation with kwargs, exception path, malformed JSON
- `--json-file`, `--pretty`, `--output` semantics
- regression guard: registry retains >=10 verb groups

Existing CLI tests (`test_cli.py`, `test_cli_golden.py`) still pass.
Golden snapshots regenerated to lock the new help layout.

**Test summary**: 477 passed, 30 skipped (was 446 passed before c3).
Ruff lint + format clean.

## Rubric

- **TDD**: 31 tests written RED-first (verified failing pre-implementation).
- **Evidence-first**: smoke run of all 4 CLI surfaces captured in
  commit message + above.
- **Container/automation-first**: pure CI-aligned via existing GitHub Actions matrix.
- **Token-efficient**: zero new dependencies; reuses existing
  `registry.verb_groups()` API.
- **Backwards compatible**: `pdf-mcp serve` unchanged;
  `python -m pdf_mcp.server` still works.
- **Clean architecture**: registry remains the single source of truth;
  CLI is a thin reflection layer.

## Test plan

- [x] `pytest -q` (full suite, 477 passed)
- [x] `pdf-mcp --help` (smoke, ~830 ms cold)
- [x] `pdf-mcp form --help` (lists 9 tools)
- [x] `pdf-mcp ai get-llm-backend-info --pretty` (real JSON output)
- [x] `pdf-mcp --version` (1.2.18)
- [x] `pdf-mcp serve` regression check via existing test_cli.py

## Refs

- TICKET-05 commit 3 of 4
- Builds on PR #47 (registry-driven server.py + parity tests, merged)
- Independent of PR #48 (TICKET-08 c2 coverage gate)