### PR TITLE
docs: TICKET-05 c4 docs hardening (USAGE.md generator + README rewrite + CONTRIBUTING)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,24 @@ jobs:
           make install
           . .venv/bin/activate && python scripts/cursor_smoke.py --out-dir /tmp/pdf-handler-ci-smoke
 
+  docs-sync:
+    name: Docs sync (USAGE.md vs registry)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Verify USAGE.md is in sync with registry
+        run: |
+          make install
+          . .venv/bin/activate
+          python scripts/generate_usage_doc.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,31 @@ This project follows Keep a Changelog and Semantic Versioning.
   must match `registry.iter_all()` exactly, and a sentinel set of 19
   hand-picked tools must remain reachable. **TICKET-13**.
 
+### Added (docs hardening, TICKET-05 commit 4)
+- **`USAGE.md`**: New auto-generated CLI reference. Renders the verb-group
+  table (10 verbs / 57 tools) and per-verb tool listings derived
+  directly from `pdf_mcp.registry.verb_groups()`. The generator
+  script `scripts/generate_usage_doc.py` supports `--check` mode for
+  a CI guard so `USAGE.md` cannot drift from the registry. New CI job
+  `docs-sync` runs `python scripts/generate_usage_doc.py --check` on
+  every PR to enforce this.
+- **README rewritten as CLI-first**: top-level title is now `pdf-mcp`,
+  Quick start leads with `pdf-mcp form get-pdf-form-fields ...` style
+  invocations, and a new "CLI surface (v1.3.0+)" section summarises
+  verb groups + JSON kwargs flags. The MCP server stays a peer use
+  case, not the only one. The Python API tool list is now framed as a
+  reference for direct `pdf_mcp.pdf_tools` callers.
+- **`CONTRIBUTING.md`**: New contributor guide explaining the registry
+  pattern, the lazy-import invariant, the four-step workflow for adding
+  a new tool (implement → register → regenerate USAGE.md → test), and
+  the pre-commit / coverage / conventional-commit gates.
+- **10 new tests** in `tests/test_usage_doc_generator.py`: verify
+  `_render()` lists every verb group and every tool CLI name, includes
+  the invocation section + backwards-compat note, exits 1 in
+  `--check` mode when the file is missing or drifted (without
+  writing), and pins `USAGE.md` on disk byte-for-byte against the
+  rendered output.
+
 ### Fixed
 - **Broken regex fallback in `scripts/check_release_ready.py:42`**: the
   raw-string pattern used double-escaped backslashes (`\\s`), which inside

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,207 @@
+# Contributing to pdf-mcp
+
+Thanks for your interest in pdf-mcp! This guide focuses on the
+**architecture** that contributors most need to understand: the
+single-source registry that drives both the CLI and the MCP server,
+and the workflow for adding a new tool.
+
+For test / lint / release mechanics see [`docs/`](docs/) and
+[`README.md`](README.md).
+
+## Repository layout
+
+```
+pdf_mcp/
+  registry.py          single source of truth for tools (verb, name, description, callable)
+  cli.py               Typer CLI entry point; mounts verb groups from the registry
+  server.py            FastMCP server; mounts the same tools from the registry
+  pdf_tools.py         the actual tool implementations (heavy: pymupdf, pypdf, ...)
+  agentic_tools.py     LLM-backed tools (auto_fill, structured extraction, analysis)
+  llm_client.py        backend router (local VLM / Ollama / OpenAI)
+scripts/
+  generate_usage_doc.py  derives USAGE.md from registry.verb_groups()
+  cursor_smoke.py        end-to-end smoke that exercises the MCP server
+tests/                   pytest suite (477 tests, 75% coverage gate)
+USAGE.md                 generated; reference of every CLI command
+```
+
+## The registry pattern
+
+`pdf_mcp/registry.py` is the only place where tools are declared. Both
+the CLI (`pdf_mcp/cli.py`) and the MCP server (`pdf_mcp/server.py`)
+iterate over `registry.iter_all()` / `registry.verb_groups()` to mount
+their surfaces, so there is no duplicate list of tools to keep in sync.
+
+A tool is a `PdfTool` dataclass with five fields:
+
+| Field | What it carries |
+|-------|-----------------|
+| `name` | MCP tool name (`snake_case`); also the CLI command after `_` -> `-` translation |
+| `verb` | One of `form / pages / text / extract / sign / metadata / ocr / ai / batch / security` (defined in `_VERB_HELP`) |
+| `description` | One-sentence human description used in `--help`, USAGE.md, and the MCP schema |
+| `callable` | A `LazyCallable("module:attr")` that resolves on first invocation |
+| `schema` / `output_schema` | Reserved for a future ticket (auto-generated Typer params) |
+
+### Why lazy callables?
+
+`pdf_mcp.pdf_tools` pulls in `pymupdf`, `pypdf`, optional `openai`, and
+many other heavy modules. We do not want `pdf-mcp --help` to pay for
+that import. `LazyCallable("pdf_mcp.pdf_tools:fill_pdf_form")` only
+calls `importlib.import_module("pdf_mcp.pdf_tools")` when the tool is
+actually invoked, so the help / version paths stay sub-second.
+
+This is enforced by tests in
+[`tests/test_cli_verb_groups.py::TestLazyImportPreserved`](tests/test_cli_verb_groups.py)
+and [`tests/test_registry.py`](tests/test_registry.py).
+
+## Adding a new tool
+
+The work is roughly: write the function, register it, regenerate
+docs. There is no separate CLI plumbing or MCP plumbing.
+
+### 1. Implement the function
+
+Put the new function in `pdf_mcp/pdf_tools.py` (or
+`pdf_mcp/agentic_tools.py` for LLM-backed tools). Keep the signature
+JSON-friendly:
+
+* paths as strings or `pathlib.Path`
+* dicts and lists for structured args
+* avoid Python objects that don't round-trip JSON
+
+Return either a primitive, a list, or a dict. The CLI auto-serialises
+the return value as JSON and the MCP server hands it back to the host.
+
+```python
+# pdf_mcp/pdf_tools.py
+def shrink_pdf(input_path: str, output_path: str, quality: str = "medium") -> dict:
+    """Compress a PDF to reduce file size.
+
+    Args:
+        input_path: source PDF path.
+        output_path: destination PDF path.
+        quality: "low" (max compression), "medium", "high".
+
+    Returns:
+        ``{"output_path": "...", "size_before": int, "size_after": int}``
+    """
+    ...
+```
+
+### 2. Register the tool
+
+Add a single `register_tool(...)` call to
+`pdf_mcp.registry._seed_default_registry()`:
+
+```python
+register_tool(
+    name="shrink_pdf",
+    verb="pages",
+    description="Compress a PDF to reduce file size.",
+    import_path=f"{pt}:shrink_pdf",
+)
+```
+
+The `description` becomes the one-line help shown in `pdf-mcp pages
+--help`, in `USAGE.md`, and in the MCP tool schema. Keep it under
+~80 characters; longer prose belongs in the docstring.
+
+If you need a brand-new verb, add it to `_VERB_HELP` first with a
+short verb-level description.
+
+### 3. Regenerate the usage docs
+
+```bash
+python scripts/generate_usage_doc.py
+```
+
+`USAGE.md` updates in place. Commit it alongside your tool change so
+reviewers see both the registry diff and the doc diff.
+
+### 4. Test it
+
+Add a focused test that exercises the new function directly. The CLI
+and MCP layers do not need new tests for routine adds — the existing
+parametrised tests in `tests/test_cli_verb_groups.py` and
+`tests/test_server_registry_parity.py` automatically cover any new
+registry entry on the next run. They will fail if you forget step 2 or
+break the lazy-import invariant.
+
+Quick smoke from the CLI:
+
+```bash
+pdf-mcp pages shrink-pdf --json '{
+  "input_path": "fixture.pdf",
+  "output_path": "/tmp/out.pdf",
+  "quality": "low"
+}' --pretty
+```
+
+### 5. Update the changelog
+
+Add an entry under `## Unreleased` in `CHANGELOG.md` under `### Added`,
+following the style of existing entries.
+
+## Tests, lint, format
+
+| Goal | Command |
+|------|---------|
+| Run the full suite (with coverage gate) | `make test` |
+| Quick run, no coverage | `pytest -q --no-cov` |
+| OCR-specific tests (Tesseract required) | `make test-ocr` |
+| LLM mock tests | `make test-llm` |
+| Lint changed files (diff vs main) | `make lint` |
+| Format changed files (diff vs main) | `make format-check` |
+| Pre-push gate (lint + format + test + smoke) | `make prepush` |
+
+Coverage gate: `pytest` is configured with
+`--cov=pdf_mcp --cov-fail-under=75`. Below 75% line coverage CI fails.
+
+## Pre-commit hooks
+
+CI runs the same `pre-commit` hooks the local repo does:
+`ruff format`, `ruff check`, `end-of-file-fixer`, `trailing-whitespace`,
+`check-added-large-files`, `check-yaml`, and a tiny `py_compile` of
+repo scripts. The hooks only run on files changed in your branch.
+
+If a hook fails in CI, run the same step locally and re-push:
+
+```bash
+ruff format <file>      # or: pre-commit run --files <file>
+ruff check --fix <file>
+```
+
+## Conventional commits
+
+The repo enforces conventional commits via a CI gate. Use the standard
+prefixes: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`,
+`perf`, `style`. Scope is optional but should NOT contain version
+numbers (e.g. use `feat: ...` or `feat(cli): ...`, not
+`feat(v1.3.0): ...`).
+
+Examples:
+
+```
+feat: add shrink_pdf tool with three quality presets
+fix(extract): handle PDFs without text layer in extract_text
+docs: regenerate USAGE.md after shrink_pdf
+test: lock shrink_pdf size budget at 50 percent reduction for medium quality
+chore: bump pytest-cov pin
+```
+
+## Architecture decisions
+
+* **Single source of truth.** Tools are declared once in the registry.
+  Anything that needs the canonical tool list (CLI, MCP server, docs
+  generator, tests) reads from `pdf_mcp.registry`.
+* **Lazy imports.** `pdf-mcp --help` and `import pdf_mcp.cli` MUST NOT
+  pull in `pdf_tools`. Adding a tool does not change this invariant
+  because the registry only stores a `LazyCallable("module:attr")`,
+  not the function itself.
+* **JSON over kwargs.** The CLI uses `--json '{...}'` rather than
+  per-tool argparse for the v1.3.0 baseline. This keeps the CLI surface
+  uniform across all 57 tools and lets future tickets layer
+  hand-curated ergonomic flags on top of stable behaviour.
+* **Backwards compatibility.** `pdf-mcp serve` is a permanent alias for
+  `python -m pdf_mcp.server`. Existing Cursor / Claude Desktop configs
+  must not need to change across minor releases.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# PDF MCP Server
+# pdf-mcp
 
-MCP server for PDF form filling, editing, OCR text extraction, table extraction, image extraction, link extraction, and batch processing.
+A first-class **command-line tool** and **Model Context Protocol (MCP)
+server** for everything PDF: form filling, page operations, OCR,
+metadata, signatures, redaction, image and table extraction, batch
+processing, and LLM-backed document understanding.
 
 Built with Python, `pypdf`, `fillpdf`, and `pymupdf` (AGPL).
 
-**Goal**: Extract 99% of information from any PDF file, including scanned/image-based documents, and fill any PDF forms.
+**Goal**: Extract 99% of information from any PDF file, including
+scanned / image-based documents, and fill any PDF form. Works equally
+well as a daily CLI for humans, as a CI / automation script, and as an
+MCP server inside Cursor or Claude Desktop.
 
 ## Status
 [![Release](https://img.shields.io/github/v/release/nfsarch33/pdf-mcp-server?style=flat&label=release)](https://github.com/nfsarch33/pdf-mcp-server/releases/latest)
@@ -13,46 +19,97 @@ Built with Python, `pypdf`, `fillpdf`, and `pymupdf` (AGPL).
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-## Quick Start
+## Quick start
 
 ```bash
-# Clone and setup
+# 1. Install (project root)
 git clone https://github.com/nfsarch33/pdf-mcp-server.git
 cd pdf-mcp-server
-uv pip install -r requirements.txt
+make install      # uv-based install of runtime requirements
 
-# Run tests
+# 2. Try the CLI
+pdf-mcp --help                                    # top-level help
+pdf-mcp form --help                               # 9 form-handling tools
+pdf-mcp ai get-llm-backend-info --pretty          # check LLM backends
+
+# 3. Run as an MCP server (Cursor, Claude Desktop, etc.)
+pdf-mcp serve                                     # stdio transport
+
+# 4. Run the tests
 make test
-
-# Start the MCP server
-python -m pdf_mcp.server
 ```
 
-## CLI Usage (v1.3.0+)
-
-`pdf-mcp` now ships as a first-class CLI alongside the MCP server. Once installed
-(`uv tool install pdf-mcp`, `pip install pdf-mcp`, or `pip install -e .` from a
-checkout), the `pdf-mcp` binary is on your `$PATH`:
+Run the CLI on a real PDF:
 
 ```bash
-# Print version
-pdf-mcp --version
+# Read form fields
+pdf-mcp form get-pdf-form-fields \
+  --json '{"pdf_path":"sample.pdf"}' --pretty
 
-# List available subcommands
-pdf-mcp --help
+# Fill a form (writes filled.pdf)
+pdf-mcp form fill-pdf-form --json '{
+  "input_path": "sample.pdf",
+  "output_path": "filled.pdf",
+  "data": {"Name": "Jane Doe", "Email": "jane@example.com"},
+  "flatten": false
+}'
 
-# Run as an MCP server over stdio
-# (drop-in replacement for `python -m pdf_mcp.server`)
-pdf-mcp serve
+# OCR a scanned PDF
+pdf-mcp extract extract-text --json '{
+  "pdf_path": "scanned.pdf",
+  "engine": "ocr",
+  "language": "eng"
+}' --pretty
 ```
 
-The original `python -m pdf_mcp.server` invocation continues to work
-unchanged, so existing Cursor / Claude Desktop / CLI integrations do not
-need to be reconfigured. New verb groups (`form`, `pages`, `text`,
-`extract`, `annotate`, `sign`, `ai`) will land in subsequent v1.3.x
-releases — see the v1.3.0 sprint backlog in
-`session-handoffs/evidence/v257-w1-d0-foundation/pdf-mcp-server-2sprint-backlog.md`
-for the full roadmap.
+## CLI surface (v1.3.0+)
+
+`pdf-mcp` ships **all 57 underlying tools** as CLI subcommands grouped
+by verb. The taxonomy comes directly from `pdf_mcp.registry`, so the
+CLI and MCP surfaces never drift.
+
+| Verb | Tools | Examples |
+|------|-------|----------|
+| `pdf-mcp form` | 9 | `fill-pdf-form`, `get-pdf-form-fields`, `flatten-pdf` |
+| `pdf-mcp pages` | 8 | `merge-pdfs`, `split-pdf`, `extract-pages`, `rotate-pages` |
+| `pdf-mcp text` | 13 | `redact-text-regex`, `add-text-watermark`, `add-bates-numbering` |
+| `pdf-mcp extract` | 7 | `extract-text`, `extract-tables`, `extract-images`, `extract-links` |
+| `pdf-mcp metadata` | 4 | `get-pdf-metadata`, `set-pdf-metadata`, `sanitize-pdf-metadata` |
+| `pdf-mcp sign` | 6 | `sign-pdf`, `verify-digital-signatures`, `add-signature-image` |
+| `pdf-mcp ocr` | 2 | `get-ocr-languages`, `get-image-info` |
+| `pdf-mcp ai` | 4 | `auto-fill-pdf-form`, `extract-structured-data`, `analyze-pdf-content` |
+| `pdf-mcp batch` | 2 | `batch-process`, `compare-pdfs` |
+| `pdf-mcp security` | 2 | `encrypt-pdf`, `detect-pii-patterns` |
+| `pdf-mcp serve` | — | Run as an MCP server over stdio (drop-in for `python -m pdf_mcp.server`). |
+
+Every command accepts:
+
+```
+pdf-mcp <verb> <tool> [--json '{...}'] [--json-file PATH]
+                      [--pretty] [--output PATH]
+```
+
+* `--json` and `--json-file` are mutually exclusive (`--json` wins).
+* `--pretty` indents the JSON output for human reading.
+* `--output PATH` writes the JSON result to a file instead of stdout.
+* Tool exceptions exit non-zero with `error: <tool> failed: <msg>` on
+  stderr, so the CLI is safe to use in pipelines.
+
+The full per-tool reference is in [`USAGE.md`](USAGE.md), generated
+directly from the registry by `scripts/generate_usage_doc.py`.
+
+### Why this layout?
+
+* **Verb-first** matches Unix muscle memory (`git commit`, `kubectl apply`).
+* **Same code as the MCP surface** — there is one source of truth
+  (`pdf_mcp.registry`) so a CLI invocation and an MCP tool call hit
+  identical implementations.
+* **Lazy imports** — `pdf-mcp --help` and `pdf-mcp <verb> --help`
+  do **not** load `pymupdf` or `pypdf`. The heavy dependency tree only
+  loads when a tool is actually run, so help is sub-second cold.
+* **Backwards compatible** — `pdf-mcp serve` is a drop-in replacement
+  for `python -m pdf_mcp.server`. Existing Cursor / Claude Desktop
+  configs need no changes.
 
 ## CI notes
 - Dependency Review requires GitHub Dependency Graph to be enabled in the repository settings.
@@ -128,29 +185,33 @@ Edit `~/.cursor/mcp.json`:
 ```
 Restart Cursor after saving.
 
-## Features Overview (51 tools)
+## Features overview (57 tools across 10 verbs)
 
-| Category | Tools | Description |
-|----------|-------|-------------|
-| **Form Handling** | 8 tools | Fill, clear, flatten, and create PDF forms |
-| **Page Operations** | 5 tools | Merge, extract, rotate, reorder, insert, remove pages |
-| **Annotations** | 11 tools | Text annotations, comments, watermarks, redaction, numbering, highlights |
-| **Signatures & Security** | 7 tools | Digital signing, verification, encryption |
-| **Metadata** | 3 tools | Get, set, and sanitize PDF metadata |
-| **Export & Text** | 5 tools | Unified text extraction, export to Markdown/JSON |
-| **Table Extraction** | 1 tool | Extract tables as structured data |
-| **Image Extraction** | 2 tools | Extract/analyze embedded images |
-| **Form Detection** | 1 tool | Auto-detect form fields in non-AcroForm PDFs |
-| **PII Detection** | 1 tool | Detect common PII patterns (email, phone, SSN, credit cards) |
-| **Link Extraction** | 1 tool | Extract URLs, hyperlinks, internal references |
-| **PDF Optimization** | 1 tool | Compress/reduce PDF file size |
-| **Barcode/QR Detection** | 1 tool | Detect and decode barcodes and QR codes |
-| **Page Splitting** | 1 tool | Split by bookmarks or page count (unified API) |
-| **PDF Comparison** | 1 tool | Compare two PDFs and find differences |
-| **Batch Processing** | 1 tool | Process multiple PDFs at once |
-| **Agentic AI** | 4 tools | LLM-powered form filling, entity extraction, document analysis + local VLM (v0.9.0+) |
+| Verb group | Tools | What it does |
+|------------|-------|--------------|
+| `form` | 9 | Read, fill, clear, flatten, and create PDF forms (AcroForm + label-detection fallback). |
+| `pages` | 8 | Merge, split, extract, rotate, reorder, insert, remove, optimise. |
+| `text` | 13 | Annotations, redaction, watermarks, comments, page numbers, Bates stamps. |
+| `extract` | 7 | Text blocks, tables, images, links, structured data, barcodes/QR, format export. |
+| `metadata` | 4 | Read, write, sanitise metadata + classify PDF type (searchable / image / hybrid). |
+| `sign` | 6 | PKCS#12 / PEM digital signatures + signature image stamps + verification. |
+| `ocr` | 2 | OCR language inventory + image inspection (Tesseract + optional packs). |
+| `ai` | 4 | LLM-backed form auto-fill, structured data extraction, document analysis. |
+| `batch` | 2 | Multi-file processing and PDF-vs-PDF comparison. |
+| `security` | 2 | Password encryption + PII pattern detection. |
 
-## Available Tools
+**See [`USAGE.md`](USAGE.md) for the full per-tool command reference.**
+
+The same 57 tools are exposed as MCP tools with their original
+`snake_case` names (e.g. `fill_pdf_form`, `extract_text`,
+`detect_pii_patterns`).
+
+## Available tools (Python API reference)
+
+The Python API on `pdf_mcp.pdf_tools` matches the CLI / MCP surface
+1:1. `pdf-mcp form fill-pdf-form ...` calls the same
+`pdf_tools.fill_pdf_form(...)` function as an MCP `fill_pdf_form` tool
+call. Pick the surface that matches your workflow.
 
 ### Form Handling
 - `get_pdf_form_fields(pdf_path)`: list fields and count.
@@ -403,10 +464,13 @@ make install-llm-models
 ```
 This handles Python venv, system packages, Ollama, GPU detection, and VLM runner generation for both macOS and WSL/Linux.
 
-### Test Coverage
-- **444 tests** total (includes Tier 1/2 coverage + agentic features + multi-backend + e2e tests + v1.3.0 CLI surface)
-- All tests pass with Tesseract installed
-- A small number of tests skip depending on which optional dependencies/backends are available
+### Test coverage
+- **477 tests** (Tier 1/2 + agentic features + multi-backend + e2e + v1.3.0 CLI surface + verb-group mounts).
+- 75% line coverage gate enforced in CI via `pytest --cov-fail-under=75` (see `pyproject.toml`).
+- `pytest --cov` ships in dev extras (`make install-dev`) and writes
+  `coverage.xml` for upload to coverage tools.
+- All tests pass with Tesseract installed; a small number skip
+  depending on which optional dependencies / backends are available.
 
 ## Agent Extensions (v1.0.1+)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,164 @@
+# pdf-mcp CLI Usage Reference
+
+Auto-generated from `pdf_mcp.registry` by `scripts/generate_usage_doc.py`. Do not edit by hand; re-run the generator after adding or removing a tool.
+
+## Invocation
+
+```
+pdf-mcp <verb> <tool-name> [--json '{...}'] [--json-file PATH]
+                            [--pretty] [--output PATH]
+```
+
+* `--json` and `--json-file` are mutually exclusive (`--json` wins if both are passed).
+* `--pretty` indents the JSON output for human reading.
+* `--output PATH` writes the JSON result to a file instead of stdout.
+* Tool exceptions exit non-zero with `error: <tool> failed: <msg>` on stderr.
+
+Run `pdf-mcp --help` for the top-level surface and `pdf-mcp <verb> --help` for the per-verb tool list.
+
+## Verb groups
+
+| Verb | Tools | Description |
+| ---- | ----- | ----------- |
+| `form` | 9 | PDF form discovery, filling, templates, and flattening. |
+| `security` | 2 | Encryption and PII detection. |
+| `pages` | 8 | Page-level mutation: merge, split, extract, rotate, reorder, insert, remove. |
+| `text` | 13 | Text annotations, redaction, watermarks, comments, page numbers, Bates stamps. |
+| `metadata` | 4 | Metadata read/write/sanitisation and PDF type/feature detection. |
+| `sign` | 6 | Digital and visual signatures. |
+| `extract` | 7 | Read-only extraction: text blocks, tables, images, links, structured data. |
+| `ocr` | 2 | OCR helpers and image inspection. |
+| `batch` | 2 | Multi-file processing and comparisons. |
+| `ai` | 4 | LLM-backed extraction, auto-fill, and analysis. |
+
+## `pdf-mcp form`
+
+PDF form discovery, filling, templates, and flattening.
+
+| Tool | Description |
+| ---- | ----------- |
+| `get-pdf-form-fields` | Return available form fields in the PDF. |
+| `fill-pdf-form` | Fill a PDF form with provided data. Optionally flatten to make non-editable. |
+| `fill-pdf-form-any` | Fill standard or non-standard forms using label detection when needed. |
+| `create-pdf-form` | Create a new PDF with AcroForm fields. |
+| `get-form-templates` | List built-in form templates for common workflows. |
+| `create-pdf-form-from-template` | Create a PDF form using a built-in template. |
+| `flatten-pdf` | Flatten a PDF (remove form fields/annotations). |
+| `clear-pdf-form-fields` | Clear (delete) values for PDF form fields while keeping fields fillable. |
+| `detect-form-fields` | Detect potential form fields in a PDF using text analysis. |
+
+## `pdf-mcp security`
+
+Encryption and PII detection.
+
+| Tool | Description |
+| ---- | ----------- |
+| `encrypt-pdf` | Encrypt (password-protect) a PDF using pypdf. |
+| `detect-pii-patterns` | Detect common PII patterns (email, phone, SSN, credit card) in a PDF. |
+
+## `pdf-mcp pages`
+
+Page-level mutation: merge, split, extract, rotate, reorder, insert, remove.
+
+| Tool | Description |
+| ---- | ----------- |
+| `merge-pdfs` | Merge multiple PDFs into a single file. |
+| `extract-pages` | Extract specific 1-based pages into a new PDF. |
+| `rotate-pages` | Rotate specified 1-based pages by degrees (must be multiple of 90). |
+| `reorder-pages` | Reorder pages in a PDF using a 1-based page list. |
+| `insert-pages` | Insert pages from another PDF before at_page (1-based). |
+| `remove-pages` | Remove specified 1-based pages from a PDF. |
+| `optimize-pdf` | Optimize/compress a PDF to reduce file size. |
+| `split-pdf` | Split a PDF into multiple files. |
+
+## `pdf-mcp text`
+
+Text annotations, redaction, watermarks, comments, page numbers, Bates stamps.
+
+| Tool | Description |
+| ---- | ----------- |
+| `add-text-annotation` | Add a FreeText annotation to a page (managed text insertion). |
+| `update-text-annotation` | Update an existing annotation by annotation_id. |
+| `remove-text-annotation` | Remove an existing annotation by annotation_id. |
+| `remove-annotations` | Remove annotations from given pages. Optionally filter by subtype (e.g., FreeText). |
+| `redact-text-regex` | Redact text using a regex pattern. |
+| `add-page-numbers` | Add page numbers as FreeText annotations. |
+| `add-bates-numbering` | Add Bates numbering as FreeText annotations. |
+| `add-text-watermark` | Add a simple text watermark or stamp via FreeText annotations. |
+| `add-highlight` | Add highlight annotations by text search or rectangle. |
+| `add-date-stamp` | Add a date stamp as a FreeText annotation. |
+| `add-comment` | Add a PDF comment (sticky note) using PyMuPDF. |
+| `update-comment` | Update a PDF comment by id using PyMuPDF. |
+| `remove-comment` | Remove a PDF comment by id using PyMuPDF. |
+
+## `pdf-mcp metadata`
+
+Metadata read/write/sanitisation and PDF type/feature detection.
+
+| Tool | Description |
+| ---- | ----------- |
+| `get-pdf-metadata` | Get PDF document metadata. |
+| `set-pdf-metadata` | Set basic PDF document metadata (title, author, subject, keywords). |
+| `sanitize-pdf-metadata` | Remove metadata keys from a PDF. |
+| `detect-pdf-type` | Analyze a PDF to classify its content type. |
+
+## `pdf-mcp sign`
+
+Digital and visual signatures.
+
+| Tool | Description |
+| ---- | ----------- |
+| `verify-digital-signatures` | Verify digital signatures in a PDF. |
+| `sign-pdf` | Digitally sign a PDF using a PKCS#12/PFX certificate. |
+| `sign-pdf-pem` | Digitally sign a PDF using PEM key + cert chain. |
+| `add-signature-image` | Add a signature image by inserting it on a page (PyMuPDF). |
+| `update-signature-image` | Update or resize a signature image (PyMuPDF). |
+| `remove-signature-image` | Remove a signature image by xref (PyMuPDF). |
+
+## `pdf-mcp extract`
+
+Read-only extraction: text blocks, tables, images, links, structured data.
+
+| Tool | Description |
+| ---- | ----------- |
+| `get-pdf-text-blocks` | Extract text blocks with position information from PDF. |
+| `extract-tables` | Extract tables from PDF pages. |
+| `extract-images` | Extract embedded images from PDF pages. |
+| `extract-links` | Extract links (URLs, hyperlinks, internal references) from a PDF. |
+| `detect-barcodes` | Detect and decode barcodes/QR codes in a PDF. |
+| `extract-text` | Unified text extraction with multiple engine options and optional confidence scores. |
+| `export-pdf` | Export PDF content to different formats. |
+
+## `pdf-mcp ocr`
+
+OCR helpers and image inspection.
+
+| Tool | Description |
+| ---- | ----------- |
+| `get-ocr-languages` | Get available OCR languages and Tesseract installation status. |
+| `get-image-info` | Get information about images in a PDF without extracting them. |
+
+## `pdf-mcp batch`
+
+Multi-file processing and comparisons.
+
+| Tool | Description |
+| ---- | ----------- |
+| `compare-pdfs` | Compare two PDFs and identify differences. |
+| `batch-process` | Process multiple PDFs with a single operation. |
+
+## `pdf-mcp ai`
+
+LLM-backed extraction, auto-fill, and analysis.
+
+| Tool | Description |
+| ---- | ----------- |
+| `get-llm-backend-info` | Get information about available LLM backends. |
+| `auto-fill-pdf-form` | Intelligently fill PDF form fields using LLM-powered field mapping. |
+| `extract-structured-data` | Extract structured data from PDF using pattern matching or LLM. |
+| `analyze-pdf-content` | Analyze PDF content for document type, key entities, and summary. |
+
+## Backwards compatibility
+
+* `pdf-mcp serve` runs the MCP server over stdio (drop-in replacement for `python -m pdf_mcp.server`).
+* All tools remain reachable via the MCP protocol with their original `snake_case` names.

--- a/scripts/generate_usage_doc.py
+++ b/scripts/generate_usage_doc.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Generate ``USAGE.md`` from the live :mod:`pdf_mcp.registry`.
+
+The registry is the single source of truth for the CLI / MCP surface, so
+deriving the docs from it eliminates drift entirely. Contributors who
+add a new tool with ``register_tool(...)`` re-run this script and the
+docs catch up in one commit.
+
+Usage
+-----
+
+    python scripts/generate_usage_doc.py [--out USAGE.md] [--check]
+
+* ``--out PATH``: target file (default ``USAGE.md`` at repo root).
+* ``--check``: do not write; exit 1 if the on-disk file differs from
+  what would be generated. Useful as a CI guard.
+
+The output deliberately renders Markdown only, with stable section
+order: alphabetical within each verb group, verb groups in
+``registry.verb_groups()`` order (which mirrors insertion order in
+``_seed_default_registry``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUT = REPO_ROOT / "USAGE.md"
+
+
+def _render(verb_groups: Iterable[object]) -> str:
+    """Render the full USAGE.md body from a list of VerbGroup objects."""
+    out: list[str] = []
+    out.append("# pdf-mcp CLI Usage Reference")
+    out.append("")
+    out.append(
+        "Auto-generated from `pdf_mcp.registry` by "
+        "`scripts/generate_usage_doc.py`. Do not edit by hand; re-run the "
+        "generator after adding or removing a tool."
+    )
+    out.append("")
+    out.append("## Invocation")
+    out.append("")
+    out.append("```")
+    out.append("pdf-mcp <verb> <tool-name> [--json '{...}'] [--json-file PATH]")
+    out.append("                            [--pretty] [--output PATH]")
+    out.append("```")
+    out.append("")
+    out.append("* `--json` and `--json-file` are mutually exclusive (`--json` wins if both are passed).")
+    out.append("* `--pretty` indents the JSON output for human reading.")
+    out.append("* `--output PATH` writes the JSON result to a file instead of stdout.")
+    out.append("* Tool exceptions exit non-zero with `error: <tool> failed: <msg>` on stderr.")
+    out.append("")
+    out.append("Run `pdf-mcp --help` for the top-level surface and `pdf-mcp <verb> --help` for the per-verb tool list.")
+    out.append("")
+
+    out.append("## Verb groups")
+    out.append("")
+    out.append("| Verb | Tools | Description |")
+    out.append("| ---- | ----- | ----------- |")
+    for g in verb_groups:
+        out.append(f"| `{g.verb}` | {len(g.tools)} | {g.help} |")  # type: ignore[attr-defined]
+    out.append("")
+
+    for g in verb_groups:
+        out.append(f"## `pdf-mcp {g.verb}`")  # type: ignore[attr-defined]
+        out.append("")
+        out.append(g.help)  # type: ignore[attr-defined]
+        out.append("")
+        out.append("| Tool | Description |")
+        out.append("| ---- | ----------- |")
+        for tool in g.tools:  # type: ignore[attr-defined]
+            cli_name = tool.name.replace("_", "-")
+            out.append(f"| `{cli_name}` | {tool.description} |")
+        out.append("")
+
+    out.append("## Backwards compatibility")
+    out.append("")
+    out.append("* `pdf-mcp serve` runs the MCP server over stdio (drop-in replacement for `python -m pdf_mcp.server`).")
+    out.append("* All tools remain reachable via the MCP protocol with their original `snake_case` names.")
+    return "\n".join(out) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help="Path to write USAGE.md (default: repo root)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write; exit 1 if file is out of sync.",
+    )
+    args = parser.parse_args(argv)
+
+    # Lazy import: keep this script runnable from any CWD without
+    # paying the pdf_tools dependency tax. The registry import does
+    # not pull in pdf_tools (that's the whole point of LazyCallable).
+    sys.path.insert(0, str(REPO_ROOT))
+    from pdf_mcp import registry
+
+    rendered = _render(registry.verb_groups())
+
+    if args.check:
+        if not args.out.exists():
+            print(f"USAGE.md missing at {args.out}", file=sys.stderr)
+            return 1
+        existing = args.out.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(
+                "USAGE.md is out of sync with pdf_mcp.registry. Run `python scripts/generate_usage_doc.py` and commit.",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    args.out.write_text(rendered, encoding="utf-8")
+    print(f"wrote {args.out} ({len(rendered)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_usage_doc_generator.py
+++ b/tests/test_usage_doc_generator.py
@@ -1,0 +1,127 @@
+"""Tests for ``scripts/generate_usage_doc.py``.
+
+The generator turns ``pdf_mcp.registry.verb_groups()`` into ``USAGE.md``.
+Two contracts:
+
+1. ``USAGE.md`` MUST be in sync with the live registry. Drift fails CI.
+2. ``--check`` MUST be a pure read (does not write) and must exit non-zero
+   when the file diverges.
+
+These tests run the script as an importable module so they are fast and
+do not require a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_usage_doc.py"
+USAGE_PATH = REPO_ROOT / "USAGE.md"
+
+
+@pytest.fixture(scope="module")
+def usage_doc_module():
+    """Load ``scripts/generate_usage_doc.py`` as a module.
+
+    The script is intentionally not under a Python package, so we use
+    ``importlib.util.spec_from_file_location`` (same trick as the
+    release-gate test) to load it.
+    """
+    spec = importlib.util.spec_from_file_location("_test_generate_usage_doc", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+class TestGeneratorOutput:
+    """Pin the structural contract of the rendered ``USAGE.md``."""
+
+    def test_output_starts_with_h1(self, usage_doc_module):
+        from pdf_mcp import registry
+
+        rendered = usage_doc_module._render(registry.verb_groups())
+        assert rendered.startswith("# pdf-mcp CLI Usage Reference\n")
+
+    def test_output_lists_all_verb_groups(self, usage_doc_module):
+        from pdf_mcp import registry
+
+        rendered = usage_doc_module._render(registry.verb_groups())
+        for group in registry.verb_groups():
+            assert f"## `pdf-mcp {group.verb}`" in rendered, (
+                f"USAGE.md is missing the {group.verb!r} verb-group section"
+            )
+
+    def test_output_lists_all_tool_cli_names(self, usage_doc_module):
+        from pdf_mcp import registry
+
+        rendered = usage_doc_module._render(registry.verb_groups())
+        for tool in registry.iter_all():
+            cli_name = tool.name.replace("_", "-")
+            assert f"`{cli_name}`" in rendered, f"USAGE.md is missing the {cli_name!r} CLI command"
+
+    def test_output_includes_invocation_section(self, usage_doc_module):
+        from pdf_mcp import registry
+
+        rendered = usage_doc_module._render(registry.verb_groups())
+        assert "## Invocation" in rendered
+        assert "[--json '{...}']" in rendered
+        assert "[--json-file PATH]" in rendered
+        assert "[--pretty]" in rendered
+        assert "[--output PATH]" in rendered
+
+    def test_output_includes_backwards_compat_note(self, usage_doc_module):
+        from pdf_mcp import registry
+
+        rendered = usage_doc_module._render(registry.verb_groups())
+        assert "## Backwards compatibility" in rendered
+        assert "pdf-mcp serve" in rendered
+        assert "python -m pdf_mcp.server" in rendered
+
+
+class TestCheckMode:
+    """``--check`` exits 0 when in sync, 1 when drifted, never writes."""
+
+    def test_check_passes_when_usage_md_is_current(self, usage_doc_module, capsys):
+        rc = usage_doc_module.main(["--check"])
+        assert rc == 0, capsys.readouterr().err
+
+    def test_check_fails_when_file_missing(self, usage_doc_module, tmp_path):
+        target = tmp_path / "USAGE.md"
+        rc = usage_doc_module.main(["--check", "--out", str(target)])
+        assert rc == 1
+        assert not target.exists()
+
+    def test_check_fails_when_file_drifted(self, usage_doc_module, tmp_path):
+        target = tmp_path / "USAGE.md"
+        target.write_text("stale content\n", encoding="utf-8")
+        rc = usage_doc_module.main(["--check", "--out", str(target)])
+        assert rc == 1
+        assert target.read_text(encoding="utf-8") == "stale content\n"
+
+    def test_write_mode_creates_expected_file(self, usage_doc_module, tmp_path):
+        target = tmp_path / "USAGE.md"
+        rc = usage_doc_module.main(["--out", str(target)])
+        assert rc == 0
+        body = target.read_text(encoding="utf-8")
+        assert body.startswith("# pdf-mcp CLI Usage Reference\n")
+
+
+class TestUsageMdInSyncWithRegistry:
+    """Belt-and-braces: USAGE.md on disk must match the rendered output."""
+
+    def test_usage_md_matches_registry(self, usage_doc_module):
+        from pdf_mcp import registry
+
+        expected = usage_doc_module._render(registry.verb_groups())
+        actual = USAGE_PATH.read_text(encoding="utf-8")
+        assert actual == expected, (
+            "USAGE.md is out of sync with pdf_mcp.registry. Run `python scripts/generate_usage_doc.py` and commit."
+        )


### PR DESCRIPTION
## Summary

Final commit of TICKET-05 (single-source registry). The c1/c2/c3 commits
already merged on `main` via PRs #46, #47, #49. This PR closes out the
sprint with documentation hardening so the registry pattern is
discoverable and stays in sync going forward.

* `scripts/generate_usage_doc.py` derives `USAGE.md` from the live
  `pdf_mcp.registry.verb_groups()`. `--check` mode lets CI catch drift
  without writing. New CI job `docs-sync` runs `--check` on every PR.
* `USAGE.md` lists all 10 verb groups + 57 CLI commands with one-line
  descriptions. Stable section ordering (registry insertion order) so
  future regenerations produce minimal diffs.
* `README.md` rewritten as CLI-first: top-level title is `pdf-mcp`,
  Quick start leads with `pdf-mcp form get-pdf-form-fields ...` style
  invocations, new "CLI surface (v1.3.0+)" section summarises verbs +
  JSON kwargs flags, Python API reframed as a reference. The MCP server
  remains a peer use case, not the only one.
* `CONTRIBUTING.md` explains the registry pattern, the lazy-import
  invariant, the four-step add-a-tool workflow (implement → register
  → regenerate `USAGE.md` → test), and the pre-commit / coverage /
  conventional-commit gates.
* `tests/test_usage_doc_generator.py` (10 new tests): `_render()` lists
  every verb group and CLI tool name, includes invocation +
  backwards-compat sections, `--check` exits 1 when missing or drifted
  (without writing), and pins on-disk `USAGE.md` byte-for-byte against
  the rendered output.

## Test plan

- [x] `python scripts/generate_usage_doc.py --check` exits 0 (`USAGE.md`
      is in sync with the registry).
- [x] `pytest tests/test_usage_doc_generator.py -q` — 10 passed.
- [x] `pytest tests/test_registry.py tests/test_server_registry_parity.py
      tests/test_cli.py tests/test_cli_golden.py -q` — 25 passed (no
      regression from the registry-driven `server.py`).
- [x] Pre-commit hooks pass on every staged file
      (`ruff check`, `ruff format`, `end-of-file-fixer`,
      `trim-trailing-whitespace`, `check-yaml`, `check-merge-conflicts`,
      `py_compile`).
- [x] `pdf-mcp --help` and `pdf-mcp <verb> --help` still render the
      v1.3.0 verb-grouped help (locked by golden snapshots).

## Followups (separate PRs)

- PR #48 (TICKET-08 c2 coverage gate) is rebased onto current `main`
  and queued behind this PR.
- Tech debt: `Makefile` lint/format targets and `.github/workflows/lint.yml`
  use `grep -E '\\\\.py$$'` which over-escapes the backslash and
  silently matches no Python files. Track separately; not in scope here.
